### PR TITLE
Fix render-all and enable checks for PRs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -60,8 +60,9 @@ jobs:
     with:
       check_type: spelling
       error_min: 3
-      gh_pat: secrets.GH_PAT
       branch_name: ${GITHUB_HEAD_REF}
+    secrets:
+      gh_pat: ${{ secrets.GH_PAT }}
 
   url-check:
     name: Check URLs
@@ -71,8 +72,9 @@ jobs:
     with:
       check_type: urls
       error_min: 0
-      gh_pat: secrets.GH_PAT
       branch_name: ${GITHUB_HEAD_REF}
+    secrets:
+      gh_pat: ${{ secrets.GH_PAT }}
 
   quiz-check:
     name: Check quiz formatting
@@ -82,8 +84,9 @@ jobs:
     with:
       check_type: quiz_format
       error_min: 0
-      gh_pat: secrets.GH_PAT
       branch_name: ${GITHUB_HEAD_REF}
+    secrets:
+      gh_pat: ${{ secrets.GH_PAT }}
 
 ############################# Style the code ###################################
   style-code:

--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -126,6 +126,9 @@ jobs:
           git config --global --add safe.directory $GITHUB_WORKSPACE
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git remote set-url origin https://${GH_PAT}@github.com/${GITHUB_REPOSITORY}
+          git fetch origin
+          git pull --rebase --allow-unrelated-histories --strategy-option=ours
 
       # Rendered content for Leanpub and Coursera is very similar.
       # This job creates a shared scaffold for both.
@@ -138,11 +141,9 @@ jobs:
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
         run: |
-          git remote set-url origin https://${GH_PAT}@github.com/${GITHUB_REPOSITORY}
-          git fetch origin
           git add --force docs/no_toc*
           git commit -m 'Render toc-less' || echo "No changes to commit"
-          git pull --set-upstream origin $branch_name --allow-unrelated-histories --strategy-option=ours
+          git status docs/no_toc*
           git push -u origin main  || echo "No changes to push"
 
   render-leanpub:

--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -166,6 +166,10 @@ jobs:
           git config --global --add safe.directory $GITHUB_WORKSPACE
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git remote set-url origin https://${GH_PAT}@github.com/${GITHUB_REPOSITORY}
+          git fetch origin
+          git pull --rebase --allow-unrelated-histories --strategy-option=ours
+          ls docs/no_toc
 
       # Create screenshots
       - name: Run the screenshot creation
@@ -179,6 +183,7 @@ jobs:
             --git_pat ${{ secrets.GH_PAT }} \
             --repo $GITHUB_REPOSITORY \
             --output_dir resources/chapt_screen_images)
+          rm make_screenshots.R
 
       # We want a fresh run of the renders each time
       - name: Delete manuscript/
@@ -186,11 +191,8 @@ jobs:
           GH_PAT: ${{ secrets.GH_PAT }}
         run: |
           rm -rf manuscript/
-          git remote set-url origin https://${GH_PAT}@github.com/${GITHUB_REPOSITORY}
-          git fetch origin
           git add .
           git commit -m 'Delete manuscript folder' || echo "No changes to commit"
-          git pull --set-upstream origin $branch_name --allow-unrelated-histories --strategy-option=ours
           git push -u origin main || echo "No changes to push"
 
       - name: Run ottrpal::bookdown_to_embed_leanpub
@@ -199,7 +201,7 @@ jobs:
           Rscript -e "ottrpal::bookdown_to_embed_leanpub(
             render = FALSE, \
             chapt_img_key = 'resources/chapt_screen_images/chapter_urls.tsv', \
-            make_book_txt = as.logical('${{needs.yaml-check.outputs.make_book_txt}}'), \
+            make_book_txt = as.logical('${{needs.yaml-check.outputs.make_book_txt == 'yes'}}'), \
             quiz_dir = NULL)"
 
       - name: Run ottrpal::bookdown_to_embed_leanpub
@@ -208,7 +210,7 @@ jobs:
           Rscript -e "ottrpal::bookdown_to_embed_leanpub(
             render = FALSE, \
             chapt_img_key = 'resources/chapt_screen_images/chapter_urls.tsv', \
-            make_book_txt = as.logical('${{needs.yaml-check.outputs.make_book_txt}}'))"
+            make_book_txt = as.logical('${{needs.yaml-check.outputs.make_book_txt == 'yes'}}'))"
 
       # Commit the rendered Leanpub files
       - name: Commit rendered Leanpub files
@@ -220,7 +222,8 @@ jobs:
           git add --force resources/*
           git add --force docs/*
           git commit -m 'Render Leanpub' || echo "No changes to commit"
-          git pull --allow-unrelated-histories --strategy-option=ours
+          git status docs/*
+          git pull --rebase --allow-unrelated-histories --strategy-option=ours --autostash
           git push --force --set-upstream origin main || echo "No changes to push"
 
   render-coursera:
@@ -243,6 +246,9 @@ jobs:
           git config --global --add safe.directory $GITHUB_WORKSPACE
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git remote set-url origin https://${GH_PAT}@github.com/${GITHUB_REPOSITORY}
+          git fetch origin
+          git pull --rebase --allow-unrelated-histories --strategy-option=ours
 
       # Run Coursera version
       - name: Convert Leanpub quizzes to Coursera
@@ -256,8 +262,6 @@ jobs:
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
         run: |
-          git remote set-url origin https://${GH_PAT}@github.com/${GITHUB_REPOSITORY}
-          git fetch origin
           if [ -d 'coursera_quizzes' ]; then
             git add --force coursera_quizzes/*
           fi
@@ -265,5 +269,5 @@ jobs:
           git add --force resources/*
           git add --force docs/*
           git commit -m 'Render Coursera quizzes' || echo "No changes to commit"
-          git pull --rebase --allow-unrelated-histories --strategy-option=ours
+          git status
           git push -u origin main  || echo "No changes to push"

--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -151,7 +151,7 @@ jobs:
     needs: [yaml-check, render-tocless]
     runs-on: ubuntu-latest
     container:
-      image: jhudsl/ottrpal:main
+      image: jhudsl/ottrpal
     if: ${{needs.yaml-check.outputs.toggle_leanpub == 'yes'}}
 
     steps:

--- a/config_automation.yml
+++ b/config_automation.yml
@@ -19,6 +19,10 @@ render-bookdown: yes
 render-leanpub: yes
 render-coursera: yes
 
+## Automate the creation of Book.txt file? yes/no
+## This is only relevant if render-leanpub is yes, otherwise it will be ignored
+make-book-txt: yes
+
 ##### Rendering of student guide (if applicable)
 render-student-guide: yes
 

--- a/manuscript/README.md
+++ b/manuscript/README.md
@@ -1,0 +1,1 @@
+placeholder file to see if render actions will run successfully


### PR DESCRIPTION
Noticed that the render all actions weren't successful:
- Updating github login chunk to handle multiple histories -- mimicking the template
- incorporating leanpub make book txt patch so that leanpub runs succesfully
- removed the main tag so that latest docker would be used for leanpub rendering actions
- created a manuscript folder with a placeholder README so that coursera rendering actions (specifically commiting everything to github would be successful)

Followed template files as closely as possible in making these changes.
 
Also incorporated secret handling so PR checks run