### PR TITLE
Tweak to remove chapter prefix

### DIFF
--- a/_bookdown.yml
+++ b/_bookdown.yml
@@ -12,9 +12,6 @@ rmd_files: ["index.Rmd",
 new_session: yes
 bibliography: [book.bib]
 delete_merged_file: true
-language:
-  ui:
-    chapter_name: "Chapter"
 output_dir: "docs"
 output:
     bookdown::html_book


### PR DESCRIPTION
Noticed the "Chapter" heading and number were getting mushed together.

Just took the approach in AnVIL_Demos and removed it completely: https://github.com/fhdsl/Data_on_AnVIL/blob/main/_bookdown.yml

Resolves #19  